### PR TITLE
Add FPS field if available

### DIFF
--- a/csharp/dav1dfile.Legacy.cs
+++ b/csharp/dav1dfile.Legacy.cs
@@ -95,6 +95,12 @@ namespace Dav1dfile
 		);
 
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public extern static int df_guessframerate(
+			IntPtr context,
+			out double fps
+		);
+
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
 		public extern static int df_eos(IntPtr context);
 
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]

--- a/csharp/dav1dfile.cs
+++ b/csharp/dav1dfile.cs
@@ -96,6 +96,13 @@ public static partial class Bindings
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+	public static partial int df_guessframerate(
+		IntPtr context,
+		out double fps
+	);
+
+	[LibraryImport(nativeLibName)]
+	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
 	public static partial int df_eos(IntPtr context);
 
 	[LibraryImport(nativeLibName)]

--- a/include/dav1dfile.h
+++ b/include/dav1dfile.h
@@ -81,6 +81,8 @@ DECLSPEC void df_videoinfo2(
 	PixelLayout *pixelLayout,
 	uint8_t *hbd);
 
+DECLSPEC int df_guessframerate(AV1_Context *context, double *fps);
+
 DECLSPEC int df_eos(AV1_Context *context);
 DECLSPEC void df_reset(AV1_Context *context);
 

--- a/include/dav1dfile.h
+++ b/include/dav1dfile.h
@@ -81,6 +81,17 @@ DECLSPEC void df_videoinfo2(
 	PixelLayout *pixelLayout,
 	uint8_t *hbd);
 
+/*
+ * This will attempt to guess the framerate from timing data in the sequence header.
+ * If it is present, it will set the fps value and return 1.
+ * Otherwise, the value at that pointer will not changed, and this function returns 0.
+ *
+ * Please note that as of this writing, some popular encoders (like ffpmeg) do not
+ * add this information by default, and you may have to force its inclusion, like so:
+ *
+ * ffmpeg -i input.m4v -c:v libaom-av1
+ *    -bsf:v av1_metadata=tick_rate=30000/1001:num_ticks_per_picture=1 -an output.obu
+ */
 DECLSPEC int df_guessframerate(AV1_Context *context, double *fps);
 
 DECLSPEC int df_eos(AV1_Context *context);


### PR DESCRIPTION
I believe the logic here should be correct, but I am light on samples to test with.

ffmpeg does not add this info by default, but permits you to manually specify these values, e.g.:

```ffmpeg -I input.m4v -c:v libaom-av1 -bsf:v av1_metadata=tick_rate=30000/1001:num_ticks_per_picture=1 -an output.obu```